### PR TITLE
Automatically source env vars + OSX support fixes

### DIFF
--- a/functions/aws-sso-creds.bash
+++ b/functions/aws-sso-creds.bash
@@ -1,25 +1,53 @@
 aws-sso-creds() {
-  local account_id role_name access_token region
-  account_id="$(aws configure get sso_account_id --profile ${AWS_PROFILE})"
-  role_name="$(aws configure get sso_role_name --profile ${AWS_PROFILE})"
-  region="$(aws configure get region --profile ${AWS_PROFILE})"
-  access_token="$( \
-    \ls -c "${HOME}/.aws/sso/cache/" | grep -v botocore \
-    | sort -nr | cut -d' ' -f2 | head -n1 \
-    | xargs -I{} jq -r .accessToken ${HOME}/.aws/sso/cache/{}
-  )"
-  aws sso get-role-credentials \
+  unset \
+    AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY \
+    AWS_SESSION_TOKEN \
+    AWS_CREDENTIALS_EXPIRATION \
+    AWS_REGION
+
+  local profile
+  profile="${1:-${AWS_PROFILE}}"
+  if [[ -z "${profile}" ]]; then
+    >&2 echo ":: missing profile"
+    return 1
+  fi
+
+  local account_id role_name region start_url
+  account_id="$(aws configure get sso_account_id --profile ${profile})"
+  role_name="$(aws configure get sso_role_name --profile ${profile})"
+  region="$(aws configure get region --profile ${profile})"
+  region="${region:-us-east-1}"
+  start_url="$(aws configure get sso_start_url --profile "${profile}")"
+
+  if [ -z "$start_url" ] ; then
+    >&2 echo ":: missing sso_start_url for profile ${profile}"
+    return 1
+  fi
+
+  local cache_sha cache_file
+  cache_sha="$(echo -n "$start_url" | sha1sum | awk '{print $1}')"
+  cache_file="${HOME}/.aws/sso/cache/${cache_sha}.json"
+
+  local access_token
+  access_token="$(<"${cache_file}" jq -rM '.accessToken')"
+  # the <<<"$(cat <())" hack is for OSX bash 3.2
+  . /dev/stdin <<<"$(cat <(aws sso get-role-credentials \
     --account-id "${account_id}" \
     --role-name "${role_name}" \
-    --region "${region:-us-east-1}" \
+    --region "${region}" \
     --access-token "${access_token}" \
     --no-sign-request \
     --output json \
-    | jq -r '.roleCredentials |
+    | jq -rM '.roleCredentials |
       {
         "AWS_ACCESS_KEY_ID": .accessKeyId,
         "AWS_SECRET_ACCESS_KEY": .secretAccessKey,
         "AWS_SESSION_TOKEN": .sessionToken,
         "AWS_CREDENTIALS_EXPIRATION": (.expiration / 1000 | todate)
       } | keys[] as $k | "export \($k)=\(.[$k])"'
+  ))"
+  export AWS_REGION="${region}"
+  unset AWS_PROFILE
+  env | grep AWS_
 }


### PR DESCRIPTION
- Automatically source the env vars
- Make it work in OSX, since the typical approach of source + process substitution I've used in the past does not work on OSX bash 3.2
- Implemented some suggestions from https://github.com/aws/aws-cli/issues/5261