### PR TITLE
fix: correct bash array handling and syntax in gcd autocomplete function

### DIFF
--- a/functions/gcd.bash
+++ b/functions/gcd.bash
@@ -57,24 +57,20 @@ _gcd_completions() {
   done
 
 	log_debug "#:${#suggestions[@]}"
-	if [[ "${#suggestions[@]}" -eq -0 ]]; then
+	if [[ "${#suggestions[@]}" -eq 0 ]]; then
 		true
 	elif [[ "${#suggestions[@]}" -eq 1 ]]; then
 		log_debug "s[0]:'${suggestions[0]}'"
 		if [[ "$find_root" == "${suggestions[0]}" ]]; then
-			COMPREPLY="${current_input}/"
+			COMPREPLY=("${current_input}/")
 		elif [[ -z "$current_input" ]]; then
-			COMPREPLY="${current_input}"
+			COMPREPLY=("${current_input}")
 		else
 			COMPREPLY="${difference}${suggestions[0]}"
 		fi
-		log_debug "cr:'${COMPREPLY}'"
+		log_debug "cr:'${COMPREPLY[*]}'"
 	else
-		final=()
-		for path in "${suggestions[@]}"; do
-			final+=("${difference}${path}")
-		done
-		COMPREPLY=("${final[@]}")
+		COMPREPLY=("${suggestions[@]}")
 	fi
 }
 


### PR DESCRIPTION
> [!NOTE]
> - Fixed bash array comparison syntax by removing extra minus sign in condition check
> - Corrected COMPREPLY array assignment to use proper array syntax with parentheses
> - Simplified completion logic by directly assigning suggestions array to COMPREPLY instead of creating intermediate array
> - Updated debug logging to properly display array contents using `${COMPREPLY[*]}` syntax

This change fixes several bash syntax errors in the `gcd` directory navigation autocomplete functionality, ensuring proper array operations and eliminating potential runtime errors during tab completion.